### PR TITLE
Change cluster_backup to match alias, cluster_backup_controller

### DIFF
--- a/stable/cluster-backup-chart/templates/clusterbackup-deployment.yaml
+++ b/stable/cluster-backup-chart/templates/clusterbackup-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           operator: Exists
       containers:
       - name: cluster-backup
-        image: {{ .Values.global.imageOverrides.cluster_backup }}
+        image: {{ .Values.global.imageOverrides.cluster_backup_controller }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         resources:
         {{- toYaml .Values.clusterbackup.resources | nindent 10 }}

--- a/stable/cluster-backup-chart/values.yaml
+++ b/stable/cluster-backup-chart/values.yaml
@@ -9,7 +9,7 @@ org: open-cluster-management
 global:
   pullPolicy: Always
   imageOverrides:
-    cluster_backup: ""
+    cluster_backup_controller: ""
   certificateAuthority:
     issuer: multicloud-ca-issuer
     kind: Issuer


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>
* Change image name to match alias.

Alias reference: https://github.com/open-cluster-management/pipeline/blob/eec58802fb892a119134a67e7064671e9ea1e388/image-alias.json#L59