### PR TITLE
Add rbac rules for clusterrole and clusterrolebinding

### DIFF
--- a/stable/cluster-backup-chart/templates/clusterbackup-clusterrole.yaml
+++ b/stable/cluster-backup-chart/templates/clusterbackup-clusterrole.yaml
@@ -32,6 +32,26 @@ rules:
   verbs:
   - create
 
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+
 - verbs:
   - list
   - get


### PR DESCRIPTION
Signed-off-by: sahare <sahare@redhat.com>

Based on RBAC rules added here https://github.com/open-cluster-management/cluster-backup-operator/pull/37