### PR TITLE
create policy to check if acm backup is installed and enabled

### DIFF
--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
-    policy.open-cluster-management.io/categories: PR.PT Protective Technology
-    policy.open-cluster-management.io/controls: PR.PT-3 Least Functionality
+    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted, maintained, and tested
     policy.open-cluster-management.io/standards: NIST-CSF
   name: {{ .Values.BackupRestorePolicyName }}
   namespace: {{ .Release.Namespace }}
@@ -163,7 +163,3 @@ spec:
         operator: In
         values:
           - local-cluster
-status:
-  decisions:
-    - clusterName: local-cluster
-      clusterNamespace: local-cluster

--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
-    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted, maintained, and tested
+    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
     policy.open-cluster-management.io/standards: NIST-CSF
   name: {{ .Values.BackupRestorePolicyName }}
   namespace: {{ .Release.Namespace }}

--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -1,0 +1,169 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    policy.open-cluster-management.io/categories: PR.PT Protective Technology
+    policy.open-cluster-management.io/controls: PR.PT-3 Least Functionality
+    policy.open-cluster-management.io/standards: NIST-CSF
+  name: {{ .Values.BackupRestorePolicyName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-backup-pod-running
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  labels:
+                    app: {{ template "clusterbackup.name" . }}
+                  namespace: {{ .Release.Namespace }}
+                status:
+                  phase: Running
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: oadp-pod-running
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  annotations:
+                    repository: https://github.com/openshift/oadp-operator
+                  namespace: {{ .Values.OADPOperatorNamespace }}
+                status:
+                  phase: Running
+          remediationAction: inform
+          severity: high 
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: velero-pod-running
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  labels:
+                    app.kubernetes.io/name: velero
+                  namespace: {{ .Values.OADPOperatorNamespace }}
+                status:
+                  phase: Running
+          remediationAction: inform
+          severity: high
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: storagelocation-available
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: BackupStorageLocation
+                metadata:
+                  namespace: {{ .Values.OADPOperatorNamespace }}
+                status:
+                  phase: Available
+          remediationAction: inform
+          severity: high 
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-managed-clusters-schedule-backups-available
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  labels:
+                    velero.io/schedule-name: acm-managed-clusters-schedule
+                status:
+                  phase: Completed
+          remediationAction: inform
+          severity: high 
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: acm-resources-schedule-backups-available
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: velero.io/v1
+                kind: Backup
+                metadata:
+                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  labels:
+                    velero.io/schedule-name: acm-resources-schedule
+                status:
+                  phase: Completed
+          remediationAction: inform
+          severity: high                                                
+  remediationAction: inform
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+  name: {{ .Values.BackupRestorePolicyName }}
+  namespace: {{ .Release.Namespace }}
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: {{ .Values.BackupRestorePolicyName }}
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: {{ .Values.BackupRestorePolicyName }}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+  name: {{ .Values.BackupRestorePolicyName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values:
+          - local-cluster
+status:
+  decisions:
+    - clusterName: local-cluster
+      clusterNamespace: local-cluster

--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -75,7 +75,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: storagelocation-available
+          name: backup-storage-location-available
         spec:
           object-templates:
             - complianceType: musthave

--- a/stable/cluster-backup-chart/values.yaml
+++ b/stable/cluster-backup-chart/values.yaml
@@ -55,3 +55,5 @@ clusterbackup:
       cpu: "50m"
 
 
+BackupRestorePolicyName: backup-restore-enabled
+OADPOperatorNamespace: openshift-adp


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/19214

The policy is created on chart install or update
 If policy exists it deletes the previous version and installs the new version

<img width="1181" alt="Screen Shot 2022-01-18 at 3 22 43 PM" src="https://user-images.githubusercontent.com/43010150/150013007-1f41f63b-b8ae-47b7-a097-1f7bdc430dfa.png">


<img width="1193" alt="Screen Shot 2022-01-19 at 9 38 49 AM" src="https://user-images.githubusercontent.com/43010150/150152462-4b21c261-5eed-42ae-b07d-30284d5a068d.png">


<img width="1416" alt="Screen Shot 2022-01-18 at 3 24 06 PM" src="https://user-images.githubusercontent.com/43010150/150013031-60a3eb1a-10c0-4b48-9c12-59dd71d09b70.png">
<img width="1193" alt="Screen Shot 2022-01-18 at 3 24 15 PM" src="https://user-images.githubusercontent.com/43010150/150013043-6a7a8525-ff8d-4f90-a343-88519e7e2b95.png">
<img width="1200" alt="Screen Shot 2022-01-18 at 3 24 25 PM" src="https://user-images.githubusercontent.com/43010150/150013051-10731e53-8c6e-428d-84b2-7f7fe55e8a2b.png">

