### PR TITLE
add policy.open-cluster-management.io/source: system label

### DIFF
--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -9,6 +9,7 @@ metadata:
     policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
     policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
     policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/source: system
   name: {{ .Values.BackupRestorePolicyName }}
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

fixes https://github.com/stolostron/backlog/issues/19248

Changes :
Add this label to the policy
The label should be used to tag this policy as created by the system ( not by the user )
```
apiVersion: policy.open-cluster-management.io/v1
kind: Policy
metadata:
  annotations:
    "helm.sh/hook": pre-install,post-upgrade
    "helm.sh/hook-delete-policy": before-hook-creation
    policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
    policy.open-cluster-management.io/controls: PR.IP-4 Backups of information are conducted maintained and tested
    policy.open-cluster-management.io/standards: NIST-CSF
    policy.open-cluster-management.io/source: system <<<<<<<<<<<

```

