### PR TITLE
validation resource must be in completed state

### DIFF
--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -112,6 +112,8 @@ spec:
                   labels:
                     velero.io/schedule-name: acm-validation-policy-schedule
                   namespace: {{ .Values.OADPOperatorNamespace }}
+                status:
+                  phase: Completed                  
           remediationAction: inform
           severity: high 
     - objectDefinition:


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/19776

Velero doesn't delete expired backups if they are in FailedValidation phase
Workaround this by asking for acm-validation-policy-schedule to exist in Enabled state

slack discussion
https://coreos.slack.com/archives/C0144ECKUJ0/p1646424057981139?thread_ts=1646405908.138569&cid=C0144ECKUJ0