### PR TITLE
 install oadp operator with the backup chart

### DIFF
--- a/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
+++ b/stable/cluster-backup-chart/templates/hub-backup-pod.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/name: {{ template "clusterbackup.name" . }}
     helm.sh/chart: {{ template "clusterbackup.chart" . }}
+    velero.io/exclude-from-backup: "true"
     component: policy
   annotations:
     policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
@@ -56,7 +57,7 @@ spec:
                 metadata:
                   annotations:
                     repository: https://github.com/openshift/oadp-operator
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: Running
           remediationAction: inform
@@ -75,7 +76,7 @@ spec:
                 metadata:
                   labels:
                     app.kubernetes.io/name: velero
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: Running
           remediationAction: inform
@@ -92,7 +93,7 @@ spec:
                 apiVersion: velero.io/v1
                 kind: BackupStorageLocation
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: Available
           remediationAction: inform
@@ -111,7 +112,7 @@ spec:
                 metadata:
                   labels:
                     velero.io/schedule-name: acm-validation-policy-schedule
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
           remediationAction: inform
           severity: high 
     - objectDefinition:
@@ -126,7 +127,7 @@ spec:
                 apiVersion: velero.io/v1
                 kind: Backup
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                   labels:
                     velero.io/schedule-name: acm-managed-clusters-schedule
                 status:
@@ -145,7 +146,7 @@ spec:
                 apiVersion: velero.io/v1
                 kind: Backup
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                   labels:
                     velero.io/schedule-name: acm-resources-schedule
                 status:
@@ -164,7 +165,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: BackupSchedule
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: {{ .Values.ClusterCollisionPhase }}                                                            
           remediationAction: inform
@@ -181,7 +182,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: BackupSchedule
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: FailedValidation 
             - complianceType: mustnothave
@@ -189,7 +190,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: BackupSchedule
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: Failed 
             - complianceType: mustnothave
@@ -197,7 +198,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: BackupSchedule
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: ""
             - complianceType: mustnothave
@@ -205,7 +206,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: Restore
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: ""
             - complianceType: mustnothave
@@ -213,7 +214,7 @@ spec:
                 apiVersion: cluster.open-cluster-management.io/v1beta1
                 kind: Restore
                 metadata:
-                  namespace: {{ .Values.OADPOperatorNamespace }}
+                  namespace: {{ .Release.Namespace }}
                 status:
                   phase: Error                                                       
           remediationAction: inform

--- a/stable/cluster-backup-chart/templates/oadp-operators-group.yaml
+++ b/stable/cluster-backup-chart/templates/oadp-operators-group.yaml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Open Cluster Management project
+
+# creates the OADP Operator namespace group
+# All operator resources will be installed under the {{ .Release.Namespace }} namespace
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ .Values.oadpOperator.name }}-group
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-2"
+spec:
+  targetNamespaces:
+  - {{ .Release.Namespace }}

--- a/stable/cluster-backup-chart/templates/odap-operator-pre-install-hook.yaml
+++ b/stable/cluster-backup-chart/templates/odap-operator-pre-install-hook.yaml
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Open Cluster Management project
+
+# pre hook used to install the OADP Operator, using the {{ .Values.oadpOperator.namespace }} namespace
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ .Values.oadpOperator.name }}-subscription
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/resource-policy": delete
+spec:
+  channel: {{ .Values.oadpOperator.channel }}
+  startingCSV: {{ .Values.oadpOperator.startingCSV }}
+  config:
+    resources: {}
+{{- with .Values.hubconfig.nodeSelector }}
+    nodeSelector:
+{{ toYaml . | indent 6 }}
+{{- end }}
+  installPlanApproval: {{ .Values.oadpOperator.installPlanApproval}}
+  name: {{ .Values.oadpOperator.name }}
+  source: {{ .Values.oadpOperator.source }}
+  sourceNamespace: {{ .Values.oadpOperator.sourceNamespace }}

--- a/stable/cluster-backup-chart/values.yaml
+++ b/stable/cluster-backup-chart/values.yaml
@@ -64,6 +64,13 @@ clusterbackup:
 
 
 BackupRestorePolicyName: backup-restore-enabled
-OADPOperatorNamespace: openshift-adp
 ClusterCollisionPhase: BackupCollision
+
+oadpOperator:
+  name: redhat-oadp-operator
+  channel: stable
+  installPlanApproval: Automatic
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: oadp-operator.v1.0.1
 


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

https://github.com/stolostron/backlog/issues/18711

The OADP operator will be installed in the new NS created by the installer team , named `cluster-backup`
The Policy and backup chart also installs in the same NS
