### PR TITLE
fix pull secret chart value

### DIFF
--- a/stable/cluster-backup-chart/templates/clusterbackup-deployment.yaml
+++ b/stable/cluster-backup-chart/templates/clusterbackup-deployment.yaml
@@ -76,9 +76,9 @@ spec:
             - ALL
           privileged: false
           readOnlyRootFilesystem: true
-      {{- if .Values.pullSecret }}
+      {{- if .Values.global.pullSecret }}
       imagePullSecrets:
-      - name: {{ .Values.pullSecret }}
+      - name: {{ .Values.global.pullSecret }}
       {{- end }}
 {{- with .Values.hubconfig.nodeSelector }}
       nodeSelector:

--- a/stable/cluster-backup-chart/values.yaml
+++ b/stable/cluster-backup-chart/values.yaml
@@ -8,6 +8,7 @@ org: open-cluster-management
 
 global:
   pullPolicy: Always
+  pullSecret: null
   imageOverrides:
     cluster_backup_controller: "quay.io/stolostron/cluster-backup-controller:latest"
   certificateAuthority:
@@ -40,11 +41,11 @@ affinity:
             values:
             - clusterbackup
 
-pullSecret: null
 arch:
 - amd64
 - ppc64le
 - s390x
+- arm64
 
 enabled: true
 


### PR DESCRIPTION
The MCH operator passes in the pull secret as `global.pullSecret`. This fixes the chart to use the correct parameter.

Signed-off-by: Ray Harris <raharris@redhat.com>